### PR TITLE
Fix redo shortcut on MacOS

### DIFF
--- a/src/sandbox/components/Worksheet.svelte
+++ b/src/sandbox/components/Worksheet.svelte
@@ -47,7 +47,7 @@
       undo(thisSheet);
     }
 
-    if (modifiers === 2 && e.code === 'KeyY' || modifiers === 3 && e.code === 'KeyZ') {
+    if (modifiers === 3 && e.code === 'KeyZ') {
       redo(thisSheet);
     }
 


### PR DESCRIPTION
Enable redo changes by pressing `Cmd/Ctrl + Shift + Z` only, for `Cmd/Ctrl + Y` is reserved for Show All History in all browsers under MacOS.

